### PR TITLE
Update expose.js

### DIFF
--- a/src/ventus/wm/modes/expose.js
+++ b/src/ventus/wm/modes/expose.js
@@ -16,7 +16,9 @@ define(['underscore'], function(_) {
 			this.el.on('contextmenu', _.throttle(function() {
 				// Right click sets expose mode
 				if (self.mode !== 'expose') {
-					self.mode = 'expose';
+					if(self.windows.length > 0) {
+ +						self.mode = 'expose';
+ +					}
 				} else if(self.mode === 'expose') {
 					self.mode = 'default';
 				}


### PR DESCRIPTION
Issue - Right clicking without windows loaded, created windows will have expose shadow and it becomes slow to drag.
Fix - Check displayed windows, before changing mode.