### PR TITLE
Added WindowManager margins to allow for desktop panels.

### DIFF
--- a/src/ventus/wm/window.js
+++ b/src/ventus/wm/window.js
@@ -20,7 +20,7 @@ function(Emitter, Promise, View, WindowTemplate) {
 		return isTouchEvent(e) ? e.originalEvent.changedTouches[0] : e.originalEvent;
 	}
 
-	var Window = function (options) {
+	var Window = function (wm, options) {
 		this.signals = new Emitter();
 
 		options = options || {
@@ -63,7 +63,10 @@ function(Emitter, Promise, View, WindowTemplate) {
 		if(options.content) {
 			this.$content.append(options.content);
 		}
-
+		
+		//This is a reference to the windowManager 
+		this._wm = wm;
+		
 		// Cache header element
 		this.$titlebar = this.el.find('header');
 
@@ -486,8 +489,23 @@ function(Emitter, Promise, View, WindowTemplate) {
 		},
 
 		move: function(x, y) {
-			this.x = x;
-			this.y = y;
+			var max_x = window.innerWidth - this._wm.margin.right;
+			var max_y = window.innerHeight - this._wm.margin.bottom;
+			if (x < this._wm.margin.left) {
+				this.x = this._wm.margin.left;
+			} else if (max_x < x) {
+				this.x = max_x;
+			} else {
+				this.x = x;
+			}
+			
+			if (y < this._wm.margin.top) {
+				this.y = this._wm.margin.top;
+			} else if (max_y < y) {
+				this.y = max_y;
+			} else {
+				this.y = y;
+			}
 			return this;
 		},
 

--- a/src/ventus/wm/window.js
+++ b/src/ventus/wm/window.js
@@ -20,7 +20,7 @@ function(Emitter, Promise, View, WindowTemplate) {
 		return isTouchEvent(e) ? e.originalEvent.changedTouches[0] : e.originalEvent;
 	}
 
-	var Window = function (wm, options) {
+	var Window = function (margin, options) {
 		this.signals = new Emitter();
 
 		options = options || {
@@ -65,7 +65,7 @@ function(Emitter, Promise, View, WindowTemplate) {
 		}
 		
 		//This is a reference to the windowManager 
-		this._wm = wm;
+		this._margin = margin;
 		
 		// Cache header element
 		this.$titlebar = this.el.find('header');
@@ -489,20 +489,20 @@ function(Emitter, Promise, View, WindowTemplate) {
 		},
 
 		move: function(x, y) {
-			var max_x = window.innerWidth - this._wm.margin.right;
-			var max_y = window.innerHeight - this._wm.margin.bottom;
-			if (x < this._wm.margin.left) {
-				this.x = this._wm.margin.left;
-			} else if (max_x < x) {
-				this.x = max_x;
+			var maxX = window.innerWidth - this._margin.right;
+			var maxY = window.innerHeight - this._margin.bottom;
+			if (x < this._margin.left) {
+				this.x = this._margin.left;
+			} else if (maxX < x) {
+				this.x = maxX;
 			} else {
 				this.x = x;
 			}
 			
-			if (y < this._wm.margin.top) {
-				this.y = this._wm.margin.top;
-			} else if (max_y < y) {
-				this.y = max_y;
+			if (y < this._margin.top) {
+				this.y = this._margin.top;
+			} else if (maxY < y) {
+				this.y = maxY;
 			} else {
 				this.y = y;
 			}

--- a/src/ventus/wm/windowmanager.js
+++ b/src/ventus/wm/windowmanager.js
@@ -40,6 +40,12 @@ function($, Window, View, DefaultMode, ExposeMode, FullscreenMode) {
 		}
 
 		this.windows = [];
+		this._margin = {
+			top: 0,
+			left: 0,
+			right: 0,
+			bottom: 0
+		};
 		this.active = null;
 
 		this.mode = 'default';
@@ -102,9 +108,21 @@ function($, Window, View, DefaultMode, ExposeMode, FullscreenMode) {
 		get overlay() {
 			return this._overlay;
 		},
+		
+		set margin(marginObj) {
+			if (typeof marginObj !== 'object') {
+				return;
+			}
+			this._margin = marginObj;
+			return this;
+		},
+		
+		get margin() {
+			return this._margin;
+		},
 
 		createWindow: function(options) {
-			var win = new Window(options);
+			var win = new Window(this, options);
 
 			// Show 'default' mode
 			this.mode = 'default';
@@ -199,12 +217,12 @@ function($, Window, View, DefaultMode, ExposeMode, FullscreenMode) {
 
 	WindowManager.prototype.createWindow.fromQuery = function(selector, options) {
 		options.content = View(selector);
-		return this.createWindow(options);
+		return this.createWindow(this, options);
 	};
 
 	WindowManager.prototype.createWindow.fromElement = function(element, options) {
 		options.content = View(element);
-		return this.createWindow(options);
+		return this.createWindow(this, options);
 	};
 
 	return WindowManager;

--- a/src/ventus/wm/windowmanager.js
+++ b/src/ventus/wm/windowmanager.js
@@ -113,7 +113,15 @@ function($, Window, View, DefaultMode, ExposeMode, FullscreenMode) {
 			if (typeof marginObj !== 'object') {
 				return;
 			}
-			this._margin = marginObj;
+			
+			if (marginObj.left)
+				this._margin.left = marginObj.left;
+			if (marginObj.top)
+				this._margin.top = marginObj.top;
+			if (marginObj.bottom)
+				this._margin.bottom = marginObj.bottom;
+			if (marginObj.right)
+				this._margin.right = marginObj.right;
 			return this;
 		},
 		
@@ -122,7 +130,7 @@ function($, Window, View, DefaultMode, ExposeMode, FullscreenMode) {
 		},
 
 		createWindow: function(options) {
-			var win = new Window(this, options);
+			var win = new Window(this._margin, options);
 
 			// Show 'default' mode
 			this.mode = 'default';
@@ -217,12 +225,12 @@ function($, Window, View, DefaultMode, ExposeMode, FullscreenMode) {
 
 	WindowManager.prototype.createWindow.fromQuery = function(selector, options) {
 		options.content = View(selector);
-		return this.createWindow(this, options);
+		return this.createWindow(options);
 	};
 
 	WindowManager.prototype.createWindow.fromElement = function(element, options) {
 		options.content = View(element);
-		return this.createWindow(this, options);
+		return this.createWindow(options);
 	};
 
 	return WindowManager;


### PR DESCRIPTION
This allows for setting margins on the usable area for windows. For example if the desktop had a panel at the bottom, you wouldn't want the window behind the panel because then you could not click on it. The margins work the same as CSS margins.