### PR TITLE
respect movable option during initialization

### DIFF
--- a/src/ventus/wm/window.js
+++ b/src/ventus/wm/window.js
@@ -85,7 +85,7 @@ function(Emitter, Promise, View, WindowTemplate) {
 
 		// Properties
 		this.widget = false;
-		this.movable = true;
+		this.movable = !!options.movable;
 		this.resizable = (typeof options.resizable !== 'undefined') ?
 			options.resizable :
 			true;

--- a/src/ventus/wm/window.js
+++ b/src/ventus/wm/window.js
@@ -85,7 +85,9 @@ function(Emitter, Promise, View, WindowTemplate) {
 
 		// Properties
 		this.widget = false;
-		this.movable = !!options.movable;
+		this.movable = (typeof options.movable !== 'undefined') ?
+			options.movable :
+			true;
 		this.resizable = (typeof options.resizable !== 'undefined') ?
 			options.resizable :
 			true;


### PR DESCRIPTION
to test
- open window with options `{ movable: false }`
- cannot move the window 